### PR TITLE
fix: make build run with latest versions of Hugo

### DIFF
--- a/layouts/partials/content-adapters/create-session-content.html
+++ b/layouts/partials/content-adapters/create-session-content.html
@@ -43,18 +43,14 @@
         {{ $speaker := . }}
         {{ with $url := $speaker.profilePicture }}
             {{ with resources.GetRemote $url  | images.Filter (images.Process "q90 webp") }}
-                {{ with .Err }}
-                    {{ errorf "Unable to get remote resource %s: %s" $url . }}
-                {{ else }}
-                    {{ $content := dict "mediaType" .MediaType.Type "value" .Content }}
-                    {{ $params := dict "alt" $speaker.fullName }}
-                    {{ $resource := dict
-                        "content" $content
-                        "params" $params
-                        "path" (printf "%s/avatar %s.%s" $path $speaker.id .MediaType.SubType)
-                    }}
-                    {{ $resources = $resources | append $resource }}
-                {{ end }}
+                {{ $content := dict "mediaType" .MediaType.Type "value" .Content }}
+                {{ $params := dict "alt" $speaker.fullName }}
+                {{ $resource := dict
+                    "content" $content
+                    "params" $params
+                    "path" (printf "%s/avatar %s.%s" $path $speaker.id .MediaType.SubType)
+                }}
+                {{ $resources = $resources | append $resource }}
             {{ else }}
                 {{ errorf "Unable to get remote resource %s" $url }}
             {{ end }}

--- a/layouts/partials/content-adapters/create-speaker-content.html
+++ b/layouts/partials/content-adapters/create-speaker-content.html
@@ -33,18 +33,14 @@
     {{ $item := . }}
     {{ with $url := $item.profilePicture }}
         {{ with resources.GetRemote $url  | images.Filter (images.Process "q90 webp") }}
-            {{ with .Err }}
-                {{ errorf "Unable to get remote resource %s: %s" $url . }}
-            {{ else }}
-                {{ $content := dict "mediaType" .MediaType.Type "value" .Content }}
-                {{ $params := dict "alt" $item.fullName }}
-                {{ $resource := dict
-                    "content" $content
-                    "params" $params
-                    "path" (printf "%s/avatar.%s" $path .MediaType.SubType)
-                }}
-                {{ $resources = $resources | append $resource }}
-            {{ end }}
+            {{ $content := dict "mediaType" .MediaType.Type "value" .Content }}
+            {{ $params := dict "alt" $item.fullName }}
+            {{ $resource := dict
+                "content" $content
+                "params" $params
+                "path" (printf "%s/avatar.%s" $path .MediaType.SubType)
+            }}
+            {{ $resources = $resources | append $resource }}
         {{ else }}
             {{ errorf "Unable to get remote resource %s" $url }}
         {{ end }}

--- a/layouts/partials/cta/button.html
+++ b/layouts/partials/cta/button.html
@@ -17,12 +17,10 @@
     {{- if not (page.Scratch.Get "cta_eventbrite_script_loaded") }}
         {{/* Provide Eventbrite script from own server, for performance and privacy reasons. */}}
         {{- with resources.GetRemote "https://www.eventbrite.de/static/widgets/eb_widgets.js" }}
-            {{- with .Err }}
-                {{ errorf "%s" . }}
-            {{- else }}
-                <script src="{{ .RelPermalink }}"></script>
-                {{- page.Scratch.Set "cta_eventbrite_script_loaded" true }}
-            {{- end }}
+            <script src="{{ .RelPermalink }}"></script>
+            {{- page.Scratch.Set "cta_eventbrite_script_loaded" true }}
+        {{- else }}
+            {{ errorf "Unable to load Eventbrite script." }}
         {{- end }}
     {{- end }}
 

--- a/layouts/partials/sessionize-api/view-all.html
+++ b/layouts/partials/sessionize-api/view-all.html
@@ -11,11 +11,7 @@
 {{ else }}
     {{ $url := printf "https://sessionize.com/api/v2/%s/view/all" $input.sessionizeId }}
     {{ with resources.GetRemote $url }}
-        {{ with .Err }}
-            {{ errorf "Unable to get remote resource %s: %s" $url . }}
-        {{ else }}
-            {{ $data = . | transform.Unmarshal }}
-        {{ end }}
+        {{ $data = . | transform.Unmarshal }}
     {{ else }}
         {{ errorf "Unable to get remote resource %s" $url }}
     {{ end }}


### PR DESCRIPTION
With `0.141.0` Hugo introduced a try-catch functionality (https://gohugo.io/functions/go-template/try/). Our current approach using `with .Err` doesn't seem to be correct anyway, but especially doesn't work with this new feature.

The try-catch was introduced to avoid failures during build:

> Error handling is essential when using the [resources.GetRemote](https://gohugo.io/functions/resources/getremote/) function to capture remote resources such as data or images. When calling this function, if the HTTP request fails, Hugo will fail the build.

But actually, this is the expected behavior in most/all of our cases where we use `resources.GetRemote`.

## Checklist

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes take different screen sizes into account
-   [x] My changes are backward compatible
    -   [x] I have not changed any parameter names
    -   [x] I have not changed any translation keys
-   [x] My changes conform to the contributing guidelines (`CONTRIBUTING.md`)
