### PR TITLE
Support soft word breaks in menu titles

### DIFF
--- a/content/code-of-conduct.de.md
+++ b/content/code-of-conduct.de.md
@@ -1,4 +1,4 @@
-# Verhaltenskodex
+# Verhaltens&shy;kodex
 
 ## Zielsetzung
 

--- a/hugo.spec.yaml
+++ b/hugo.spec.yaml
@@ -12,6 +12,9 @@ languages:
                   pageRef: /about
                   params:
                       description: Erfahren Sie wer wir sind uns was uns antreibt.
+                - identifier: code-of-conduct
+                  pageRef: /code-of-conduct
+                  name: Verhaltens&shy;kodex
 
 params:
     themes:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -20,7 +20,7 @@ sessions_page.room: Raum
 sessions_page.read_more: mehr erfahren
 sessions_page.heading_no_sessions: Noch keine Sessions geplant
 sessions_page.heading_come_back_soon: Schauen Sie bald wieder vorbei oder folgen Sie uns auf Social Media
-menu.code_of_conduct: Verhaltenskodex
+menu.code_of_conduct: Verhaltens&shy;kodex
 menu.about: Über uns
 menu.sessions: Programm
 menu.speakers: Sprecher

--- a/layouts/partials/menus/header.html
+++ b/layouts/partials/menus/header.html
@@ -24,7 +24,7 @@
                 {{- else }}
                     class="header-menu__link"
                 {{- end }}>
-                {{- or (T (printf "menu.%s" .Identifier)) .Name }}
+                {{- or (T (printf "menu.%s" .Identifier)) .Name | safeHTML }}
             </a>
         </li>
     {{- end }}

--- a/layouts/partials/menus/secondary.html
+++ b/layouts/partials/menus/secondary.html
@@ -13,7 +13,7 @@
                 href="{{- $item.URL }}"
                 aria-label="{{ $title }}"
                 aria-describedby="secondary-menu-description-{{ $index }}">
-                <h1 class="heading heading--3 heading--embedded">{{- $title }}</h1>
+                <h1 class="heading heading--3 heading--embedded">{{- $title | safeHTML }}</h1>
                 <div class="secondary-menu__description">
                     <p class="paragraph paragraph-embedded" id="secondary-menu-description-{{ $index }}">
                         {{- $item.Params.description | markdownify }}

--- a/layouts/partials/menus/secondary.html
+++ b/layouts/partials/menus/secondary.html
@@ -11,7 +11,7 @@
             <a
                 class="menu-item__link"
                 href="{{- $item.URL }}"
-                aria-label="{{ $title }}"
+                aria-label="{{ $title | plainify }}"
                 aria-describedby="secondary-menu-description-{{ $index }}">
                 <h1 class="heading heading--3 heading--embedded">{{- $title | safeHTML }}</h1>
                 <div class="secondary-menu__description">

--- a/layouts/partials/menus/secondary.html
+++ b/layouts/partials/menus/secondary.html
@@ -11,7 +11,7 @@
             <a
                 class="menu-item__link"
                 href="{{- $item.URL }}"
-                aria-label="{{ $title | plainify }}"
+                aria-label="{{ htmlUnescape $title }}"
                 aria-describedby="secondary-menu-description-{{ $index }}">
                 <h1 class="heading heading--3 heading--embedded">{{- $title | safeHTML }}</h1>
                 <div class="secondary-menu__description">

--- a/layouts/partials/menus/sidebar.html
+++ b/layouts/partials/menus/sidebar.html
@@ -13,7 +13,7 @@
                     class="sidebar-menu__link"
                 {{- end }}
                 aria-label="{{- or (T (printf " menu.%s" .Identifier)) .Name }}">
-                {{- or (T (printf "menu.%s" .Identifier)) .Name }}
+                {{- or (T (printf "menu.%s" .Identifier)) .Name | safeHTML }}
             </a>
         </li>
     {{- end }}

--- a/tests/secondary-menu.spec.ts
+++ b/tests/secondary-menu.spec.ts
@@ -4,13 +4,18 @@ test(`Should display the secondary menu`, async ({ page }) => {
     await page.goto('/');
 
     const menu = page.getByRole('list', { name: 'Zusätzliches Menü' });
-    const menuItems = menu.getByRole('link', { name: 'Über uns' });
+    const aboutUsMenuItem = menu.getByRole('link', { name: 'Über uns' });
+    const codeOfConductMenuItem = menu.getByRole('link', { name: 'Verhaltens­kodex' });
 
     await expect(menu).toBeVisible();
-    await expect(menuItems).toBeVisible();
-    await expect(menuItems.getByText('Erfahren Sie wer wir sind uns was uns antreibt.')).toBeVisible();
+    await expect(aboutUsMenuItem).toBeVisible();
+    await expect(aboutUsMenuItem.getByText('Erfahren Sie wer wir sind uns was uns antreibt.')).toBeVisible();
 
-    await menuItems.click();
+    await expect(codeOfConductMenuItem).toBeVisible();
+    await expect(codeOfConductMenuItem.getByText('Verhaltens­kodex')).toBeVisible();
+    //                                                     👆 hidden soft hyphen (shy)
+
+    await aboutUsMenuItem.click();
 
     await expect(page).toHaveURL('/about/');
 });

--- a/tests/secondary-menu.spec.ts
+++ b/tests/secondary-menu.spec.ts
@@ -12,8 +12,8 @@ test(`Should display the secondary menu`, async ({ page }) => {
     await expect(aboutUsMenuItem.getByText('Erfahren Sie wer wir sind uns was uns antreibt.')).toBeVisible();
 
     await expect(codeOfConductMenuItem).toBeVisible();
-    await expect(codeOfConductMenuItem.getByText('Verhaltens­kodex')).toBeVisible();
-    //                                                     👆 hidden soft hyphen (shy)
+    await expect(codeOfConductMenuItem.getByText('Verhaltens\u00ADkodex')).toBeVisible();
+    //                                                         👆 hidden soft hyphen (shy)
 
     await aboutUsMenuItem.click();
 

--- a/tests/secondary-menu.spec.ts
+++ b/tests/secondary-menu.spec.ts
@@ -5,7 +5,7 @@ test(`Should display the secondary menu`, async ({ page }) => {
 
     const menu = page.getByRole('list', { name: 'Zusätzliches Menü' });
     const aboutUsMenuItem = menu.getByRole('link', { name: 'Über uns' });
-    const codeOfConductMenuItem = menu.getByRole('link', { name: 'Verhaltens­kodex' });
+    const codeOfConductMenuItem = menu.getByRole('link', { name: 'Verhaltens\u00ADkodex' });
 
     await expect(menu).toBeVisible();
     await expect(aboutUsMenuItem).toBeVisible();


### PR DESCRIPTION
## Checklist

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes take different screen sizes into account
-   [x] My changes are backward compatible
    -   [x] I have not changed any parameter names
    -   [ ] I have not changed any translation keys
-   [x] My changes conform to the contributing guidelines (`CONTRIBUTING.md`)


<img width="371" alt="image" src="https://github.com/user-attachments/assets/afff79de-3104-4221-ab50-6e47fd2bf967" />

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/738b7c7a-7e42-4dfa-b498-4f0bb160316b" />

<img width="361" alt="image" src="https://github.com/user-attachments/assets/0708b049-2d20-4062-98b7-df61290dbb9d" />

