### PR TITLE
Hide language switcher if only one language is available

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -181,20 +181,27 @@
         <footer class="section-container">
             <section class="section section--short page-footer-section">
                 <div class="page-footer-section__start">
-                    <!-- Label for assistive technologies only -->
-                    <label for="language-select" class="sr-only">{{ T "language_menu.label" }}</label>
-                    <select id="language-select" class="select" name="language" onchange="location = this.value;">
-                        {{ range $.Site.Home.AllTranslations }}
-                            <option
-                                value="{{ .RelPermalink }}"
-                                {{ if eq .Language $.Language }}
-                                    selected
-                                {{ end }}>
-                                {{ or .Language.LanguageName .Language.Lang | upper }}
-                            </option>
-                        {{ end }}
-                    </select>
-
+                    <!-- Show language selector only if multiple languages are configured -->
+                    {{ if gt (len .Site.Languages) 1 }}
+                        <!-- Label for assistive technologies only -->
+                        <label for="language-select" class="sr-only">{{ T "language_menu.label" }}</label>
+                        <select
+                            id="language-select"
+                            class="select"
+                            name="language"
+                            onchange="location = this.value;"
+                            data-testid="language-select">
+                            {{ range $.Site.Home.AllTranslations }}
+                                <option
+                                    value="{{ .RelPermalink }}"
+                                    {{ if eq .Language $.Language }}
+                                        selected
+                                    {{ end }}>
+                                    {{ or .Language.LanguageName .Language.Lang | upper }}
+                                </option>
+                            {{ end }}
+                        </select>
+                    {{ end }}
                     {{- partial "social-links.html" (
                         dict
                         "linkedinUrl" .Site.Params.themes.event.socialLinks.linkedinUrl

--- a/tests/baseof.spec.ts
+++ b/tests/baseof.spec.ts
@@ -17,3 +17,10 @@ test('Should use short event title as a link to home page in the header menu', a
 
     await expect(page.getByRole('link', { name: /Testcon/ })).toHaveCount(2);
 });
+
+test('should not render language selector with one language', async ({ page }) => {
+    await page.goto('/');
+
+    const languageSelector = page.locator('[data-testid="language-select"]');
+    await expect(languageSelector).toHaveCount(0);
+});


### PR DESCRIPTION
## Checklist

-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes take different screen sizes into account
-   [x] My changes are backward compatible
    -   [x] I have not changed any parameter names
    -   [x] I have not changed any translation keys
-   [x] My changes conform to the contributing guidelines (`CONTRIBUTING.md`)


**Mobile view:**
![image](https://github.com/user-attachments/assets/1358f71b-b337-4633-b188-764a7004d98c)

**Desktop view:**
![image](https://github.com/user-attachments/assets/1557ec8b-f603-4f12-a412-6b224a9d1c46)
