### PR TITLE
Enhancement/rename menu

### DIFF
--- a/docs/guides/menu-configuration.md
+++ b/docs/guides/menu-configuration.md
@@ -12,9 +12,11 @@ in one place.
 
 This theme offers a `main` menu, a `footer` menu and a `secondary` menu. You can
 create menu entries for contents created by this theme and your custom contents
-(e.g. an imprint). When the menus get rendered, this theme tries to translate
-each menu entry by its identifier (`menu.` + identifier). If no translation is
-available, the name of the menu entry will be used.
+(e.g. an imprint). When the menus get rendered, user defined name properties will
+take presedence over predefined translations. If the name is empty or not set by
+the user this theme tries to translate each menu entry by its identifier
+(`menu.` + identifier). If no translation is available, a default name based on
+the identifier of the menu entry will be used.
 
 **Note:** A maximum of four menu items can be displayed in the `secondary` menu.
 
@@ -28,6 +30,7 @@ languages:
         menus:
             main:
                 - identifier: sessions
+                  name: Program
                   pageRef: /sessions
                   weight: 10
                 - identifier: code_of_conduct
@@ -48,6 +51,7 @@ languages:
         menus:
             main:
                 - identifier: sessions
+                  name: Programm
                   pageRef: /sessions
                   weight: 10
                 - identifier: code_of_conduct

--- a/layouts/miscellaneous/about.html
+++ b/layouts/miscellaneous/about.html
@@ -6,7 +6,15 @@
 
     <div class="section-container">
         <section class="section about">
-            <h1 class="heading heading--1">{{- T "about_page.heading" }}</h1>
+            <h1 class="heading heading--1">
+                {{- partial "menus/menu_label.html"
+                    (dict
+                    "menus" .Site.Menus.main
+                    "pageRef" "/about"
+                    "translationKey" "about_page.heading"
+                    )
+                }}
+            </h1>
             {{ with $event.aboutUs }}
                 <div class="markdown about__text">
                     {{ . | markdownify }}

--- a/layouts/miscellaneous/location.html
+++ b/layouts/miscellaneous/location.html
@@ -5,7 +5,13 @@
     <div class="section-container">
         <section class="section">
             <h1 class="heading heading--1">
-                {{- T "location_page.heading" }}
+                {{- partial "menus/menu_label.html"
+                    (dict
+                    "menus" .Site.Menus.main
+                    "pageRef" "/location"
+                    "translationKey" "location_page.heading"
+                    )
+                }}
             </h1>
 
             {{ with $event.address }}

--- a/layouts/partials/menus/footer.html
+++ b/layouts/partials/menus/footer.html
@@ -5,7 +5,7 @@
     {{- range $input.menu }}
         <li>
             <a class="footer-menu__link" href="{{ .URL }}" aria-label="{{- or (T (printf "menu.%s" .Identifier)) .Name }}">
-                {{- or (T (printf "menu.%s" .Identifier)) .Name }}
+                {{- or .Name (T (printf "menu.%s" .Identifier)) }}
             </a>
         </li>
     {{- end }}

--- a/layouts/partials/menus/header.html
+++ b/layouts/partials/menus/header.html
@@ -24,7 +24,7 @@
                 {{- else }}
                     class="header-menu__link"
                 {{- end }}>
-                {{- or (T (printf "menu.%s" .Identifier)) .Name | safeHTML }}
+                {{- or .Name (T (printf "menu.%s" .Identifier)) | safeHTML }}
             </a>
         </li>
     {{- end }}

--- a/layouts/partials/menus/menu_label.html
+++ b/layouts/partials/menus/menu_label.html
@@ -1,0 +1,13 @@
+{{- $pageRef := .pageRef -}}
+{{- $translationKey := .translationKey -}}
+
+{{- range .menus }}
+  {{- if eq .PageRef $pageRef }}
+    {{ if ne (lower .Name) .Identifier }}
+        {{- or .Name (T $translationKey) }}
+    {{ else }}
+        {{- or (T $translationKey) .Name }}
+    {{ end }}
+    {{- break }}
+  {{- end }}
+{{- end }}

--- a/layouts/partials/menus/secondary.html
+++ b/layouts/partials/menus/secondary.html
@@ -7,7 +7,7 @@
     {{- $firstFour := first 4 $input.menu }}
     {{- range $index, $item := $firstFour }}
         <li>
-            {{- $title :=  or (T (printf "menu.%s" $item.Identifier)) $item.Name }}
+            {{- $title :=  or $item.Name (T (printf "menu.%s" $item.Identifier)) }}
             <a
                 class="menu-item__link"
                 href="{{- $item.URL }}"

--- a/layouts/partials/menus/sidebar.html
+++ b/layouts/partials/menus/sidebar.html
@@ -13,7 +13,7 @@
                     class="sidebar-menu__link"
                 {{- end }}
                 aria-label="{{- or (T (printf " menu.%s" .Identifier)) .Name }}">
-                {{- or (T (printf "menu.%s" .Identifier)) .Name | safeHTML }}
+                {{- or .Name (T (printf "menu.%s" .Identifier)) | safeHTML }}
             </a>
         </li>
     {{- end }}

--- a/layouts/sessions/list.html
+++ b/layouts/sessions/list.html
@@ -33,7 +33,15 @@
 
     <header class="section-container">
         <div class="section">
-            <h1 class="heading heading--1">{{ T "sessions_page.heading" }}</h1>
+            <h1 class="heading heading--1">
+                {{- partial "menus/menu_label.html"
+                    (dict
+                    "menus" .Site.Menus.main
+                    "pageRef" "/sessions"
+                    "translationKey" "sessions_page.heading"
+                    )
+                }}
+            </h1>
             <div class="session-list-filters">
                 {{- if gt ($sessionsGroupedByDay | len) 1 }}
                     <article class="session-list-filter">

--- a/layouts/speakers/list.html
+++ b/layouts/speakers/list.html
@@ -1,7 +1,15 @@
 {{ define "main" }}
     <section class="speaker-list">
         <div class="section">
-            <h1 class="heading heading--1">{{ T "speakers_page.heading" }}</h1>
+            <h1 class="heading heading--1">
+                {{- partial "menus/menu_label.html"
+                    (dict
+                    "menus" .Site.Menus.main
+                    "pageRef" "/speakers"
+                    "translationKey" "speakers_page.heading"
+                    )
+                }}
+            </h1>
             <menu class="speaker-list__menu">
                 {{ range .Pages.GroupByParam "lastName" }}
                     {{ range .Pages.ByParam "firstName" }}


### PR DESCRIPTION
Addresses #39 by adding a new partial that checks
- (lower .Name) and .Location are not the same
- .Name is not empty

Uses .Name if it differs from .Location, otherwise use default string from translation.

Note: The change does not affect the sponsors page as there are two headings.

## Checklist

-   [X] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes take different screen sizes into account
-   [x] My changes are backward compatible
    -   [x] I have not changed any parameter names
    -   [x] I have not changed any translation keys
-   [x] My changes conform to the contributing guidelines (`CONTRIBUTING.md`)
